### PR TITLE
ci(jenkins): add defaultPipelineProperties call

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,8 @@ library(
     ])
 )
 
+properties(defaultPipelineProperties())
+
 pipeline {
     agent {
         node {


### PR DESCRIPTION
Add missing properties(defaultPipelineProperties()) call before pipeline block, required by Zextras Jenkins shared library standards.